### PR TITLE
fix: Add missing INDEX.md files and fix gateway skills for plugin compliance

### DIFF
--- a/skills/cloud/INDEX.md
+++ b/skills/cloud/INDEX.md
@@ -1,0 +1,480 @@
+# Cloud Computing Skills
+
+Comprehensive skills for AWS and Google Cloud Platform services, serverless computing, and cloud architecture.
+
+## Category Overview
+
+**Total Skills**: 13
+**Focus**: AWS (7 skills), GCP (6 skills), Serverless, Infrastructure, Security
+**Use Cases**: Cloud migrations, serverless applications, scalable architectures, multi-cloud deployments
+
+## Skills in This Category
+
+### AWS Skills (7 total)
+
+#### aws/aws-lambda-functions.md
+**Description**: AWS Lambda function development, runtime configuration, triggers, and optimization
+**Lines**: ~350
+**Use When**:
+- Building serverless functions triggered by events
+- Processing API requests without managing servers
+- Implementing event-driven architectures with Lambda
+- Optimizing Lambda cold start times and memory usage
+- Configuring Lambda layers for shared dependencies
+- Setting up triggers from API Gateway, S3, DynamoDB, SQS
+- Managing Lambda concurrency and performance
+
+**Key Concepts**: Lambda handlers, runtimes, layers, triggers, cold starts, concurrency, event sources
+
+---
+
+#### aws/aws-api-gateway.md
+**Description**: AWS API Gateway REST APIs, HTTP APIs, WebSocket APIs, authorization, and integration patterns
+**Lines**: ~300
+**Use When**:
+- Building REST APIs with Lambda backend
+- Creating HTTP APIs for lower latency and cost
+- Implementing WebSocket APIs for real-time communication
+- Configuring API authorization (IAM, Lambda, Cognito, API keys)
+- Setting up CORS for cross-origin requests
+- Implementing API throttling and usage plans
+- Integrating with Lambda, HTTP endpoints, or AWS services
+
+**Key Concepts**: REST vs HTTP APIs, WebSocket, authorization, CORS, throttling, integrations, Lambda proxy
+
+---
+
+#### aws/aws-databases.md
+**Description**: AWS database services - RDS, DynamoDB, ElastiCache, Aurora, migration, backup, and optimization
+**Lines**: ~350
+**Use When**:
+- Deploying managed relational databases with RDS
+- Building NoSQL applications with DynamoDB
+- Implementing caching with ElastiCache (Redis/Memcached)
+- Setting up Aurora Serverless for variable workloads
+- Migrating databases to AWS
+- Configuring database backups and point-in-time recovery
+- Optimizing database performance and read replicas
+
+**Key Concepts**: RDS, DynamoDB, ElastiCache, Aurora Serverless, DMS, backup strategies, performance tuning
+
+---
+
+#### aws/aws-iam-security.md
+**Description**: AWS IAM policies, roles, Cognito authentication, Secrets Manager, KMS encryption, and security best practices
+**Lines**: ~340
+**Use When**:
+- Creating IAM policies and roles for AWS services
+- Implementing user authentication with Cognito
+- Managing secrets with Secrets Manager or Parameter Store
+- Configuring encryption with KMS
+- Setting up temporary credentials with STS
+- Implementing least privilege access control
+- Troubleshooting permission errors or access denied issues
+
+**Key Concepts**: IAM policies, roles, Cognito, Secrets Manager, KMS, STS, least privilege, credential management
+
+---
+
+#### aws/aws-storage.md
+**Description**: AWS storage services - S3, EBS, EFS, Glacier, lifecycle policies, encryption, and data transfer
+**Lines**: ~300
+**Use When**:
+- Storing objects, files, or backups in S3
+- Attaching block storage to EC2 with EBS
+- Sharing file systems across instances with EFS
+- Archiving data long-term with Glacier
+- Configuring S3 lifecycle policies for cost optimization
+- Setting up S3 event notifications for processing
+- Implementing encryption at rest and in transit
+
+**Key Concepts**: S3 buckets, storage classes, EBS volumes, EFS, Glacier, lifecycle policies, S3 events
+
+---
+
+#### aws/aws-ec2-compute.md
+**Description**: AWS EC2 instances, Auto Scaling, Load Balancing, AMIs, and instance lifecycle management
+**Lines**: ~350
+**Use When**:
+- Deploying applications on EC2 instances
+- Configuring Auto Scaling for dynamic capacity
+- Setting up load balancers (ALB, NLB, CLB)
+- Creating and managing AMIs for deployment
+- Implementing immutable infrastructure patterns
+- Optimizing compute costs with spot instances
+- Configuring user data scripts for instance initialization
+
+**Key Concepts**: EC2 instance types, Auto Scaling Groups, Elastic Load Balancing, AMIs, spot instances, user data
+
+---
+
+#### aws/aws-networking.md
+**Description**: AWS networking - VPC, subnets, security groups, NACLs, Route53, CloudFront, Transit Gateway
+**Lines**: ~320
+**Use When**:
+- Creating VPCs and subnet architecture
+- Configuring security groups and network ACLs
+- Setting up DNS with Route53 routing policies
+- Implementing CDN with CloudFront
+- Connecting multiple VPCs with Transit Gateway
+- Setting up VPN or Direct Connect to on-premises
+- Implementing network segmentation and isolation
+
+**Key Concepts**: VPC, subnets, security groups, NACLs, Route53, CloudFront, Transit Gateway, VPN, Direct Connect
+
+---
+
+### GCP Skills (6 total)
+
+#### gcp/gcp-serverless.md
+**Description**: Google Cloud serverless services including Cloud Functions, Cloud Run, and App Engine
+**Lines**: ~360
+**Use When**:
+- Building event-driven applications with Cloud Functions
+- Deploying stateless containerized services with Cloud Run
+- Running web applications and APIs on App Engine
+- Choosing between serverless compute options
+- Configuring triggers and event routing with Eventarc
+- Scheduling tasks with Cloud Scheduler and Cloud Tasks
+- Optimizing cold start performance and concurrency
+
+**Key Concepts**: Cloud Functions, Cloud Run, App Engine, Eventarc, Cloud Scheduler, serverless patterns
+
+---
+
+#### gcp/gcp-compute.md
+**Description**: Google Cloud compute services including Compute Engine, Cloud Run, and GKE
+**Lines**: ~350
+**Use When**:
+- Deploying virtual machines on Google Cloud Platform
+- Running containerized applications with Cloud Run
+- Setting up Kubernetes clusters with GKE
+- Optimizing compute costs with preemptible VMs or committed use discounts
+- Configuring autoscaling for instance groups
+- Choosing between serverless and VM-based workloads
+- Managing SSH access and OS Login for instances
+
+**Key Concepts**: Compute Engine, instance types, preemptible VMs, GKE basics, autoscaling, managed instance groups
+
+---
+
+#### gcp/gcp-databases.md
+**Description**: Google Cloud managed database services including Cloud SQL, Firestore, Bigtable, and Spanner
+**Lines**: ~340
+**Use When**:
+- Deploying relational databases with Cloud SQL (MySQL, PostgreSQL, SQL Server)
+- Building applications with Firestore document database
+- Designing wide-column NoSQL solutions with Bigtable
+- Implementing globally distributed SQL databases with Spanner
+- Setting up Redis or Memcached caching with Memorystore
+- Migrating databases from on-premises or other clouds to GCP
+- Configuring high availability, backups, and read replicas
+
+**Key Concepts**: Cloud SQL, Firestore, Bigtable, Spanner, Memorystore, database migration, HA configuration
+
+---
+
+#### gcp/gcp-storage.md
+**Description**: Google Cloud storage services including Cloud Storage, Persistent Disk, and Filestore
+**Lines**: ~300
+**Use When**:
+- Storing objects in Cloud Storage buckets with different storage classes
+- Attaching persistent disks to Compute Engine instances
+- Setting up shared file storage with Filestore (NFS)
+- Implementing object lifecycle management and retention policies
+- Transferring large datasets to Google Cloud
+- Configuring versioning, encryption, and access controls for storage
+- Generating signed URLs for temporary access to private objects
+
+**Key Concepts**: Cloud Storage, storage classes, Persistent Disk, Filestore, lifecycle policies, signed URLs
+
+---
+
+#### gcp/gcp-iam-security.md
+**Description**: Google Cloud IAM, service accounts, Secret Manager, and Cloud KMS security practices
+**Lines**: ~330
+**Use When**:
+- Configuring IAM roles and permissions for users and services
+- Creating and managing service accounts for workloads
+- Implementing authentication with Identity Platform
+- Storing secrets and credentials in Secret Manager
+- Managing encryption keys with Cloud KMS
+- Setting up organization policies and constraints
+- Implementing least privilege access control
+
+**Key Concepts**: IAM roles, service accounts, Identity Platform, Secret Manager, Cloud KMS, organization policies
+
+---
+
+#### gcp/gcp-networking.md
+**Description**: Google Cloud networking including VPC, firewall, DNS, CDN, and load balancing
+**Lines**: ~320
+**Use When**:
+- Setting up VPC networks and subnets for GCP resources
+- Configuring firewall rules and network security policies
+- Implementing Cloud DNS for domain management
+- Enabling Cloud CDN for content delivery and caching
+- Deploying load balancers for high availability and scaling
+- Connecting on-premises networks via VPN or Cloud Interconnect
+- Optimizing network performance and reducing egress costs
+
+**Key Concepts**: VPC networks, firewall rules, Cloud DNS, Cloud CDN, load balancing, VPN, Cloud Interconnect
+
+---
+
+## Common Workflows
+
+### Serverless Web Application (AWS)
+**Goal**: Build a serverless full-stack application on AWS
+
+**Sequence**:
+1. `aws/aws-lambda-functions.md` - Implement Lambda functions for backend logic
+2. `aws/aws-api-gateway.md` - Create REST or HTTP API endpoints
+3. `aws/aws-databases.md` - Set up DynamoDB for data storage
+4. `aws/aws-iam-security.md` - Configure IAM roles and Cognito auth
+5. `aws/aws-storage.md` - Store static assets in S3 with CloudFront
+
+**Example**: Serverless blog platform with authentication
+
+---
+
+### Serverless Web Application (GCP)
+**Goal**: Build a serverless full-stack application on GCP
+
+**Sequence**:
+1. `gcp/gcp-serverless.md` - Deploy Cloud Functions or Cloud Run services
+2. `gcp/gcp-databases.md` - Set up Firestore for data storage
+3. `gcp/gcp-iam-security.md` - Configure service accounts and Identity Platform
+4. `gcp/gcp-storage.md` - Serve static content from Cloud Storage
+5. `gcp/gcp-networking.md` - Set up Cloud CDN and load balancing
+
+**Example**: Real-time collaboration platform
+
+---
+
+### Containerized Microservices (AWS)
+**Goal**: Deploy microservices on AWS with containers
+
+**Sequence**:
+1. `aws/aws-ec2-compute.md` - Set up ECS or EKS cluster
+2. `aws/aws-networking.md` - Configure VPC, subnets, and load balancers
+3. `aws/aws-databases.md` - Deploy RDS or Aurora for persistence
+4. `aws/aws-iam-security.md` - Implement IAM roles for services
+5. `aws/aws-api-gateway.md` - Add API Gateway for external access
+
+**Example**: E-commerce platform with multiple services
+
+---
+
+### Containerized Microservices (GCP)
+**Goal**: Deploy microservices on GCP with containers
+
+**Sequence**:
+1. `gcp/gcp-compute.md` - Set up GKE cluster or Cloud Run services
+2. `gcp/gcp-networking.md` - Configure VPC, firewall, and load balancing
+3. `gcp/gcp-databases.md` - Deploy Cloud SQL or Spanner
+4. `gcp/gcp-iam-security.md` - Set up service accounts and workload identity
+5. `gcp/gcp-storage.md` - Configure persistent storage and backups
+
+**Example**: Multi-tenant SaaS application
+
+---
+
+### Data Pipeline (AWS)
+**Goal**: Build a data processing pipeline on AWS
+
+**Sequence**:
+1. `aws/aws-lambda-functions.md` - Process data with Lambda functions
+2. `aws/aws-storage.md` - Use S3 for data lake storage
+3. `aws/aws-databases.md` - Store results in RDS or DynamoDB
+4. `aws/aws-iam-security.md` - Secure data access with IAM
+5. `aws/aws-api-gateway.md` - Expose data via API
+
+**Example**: Real-time analytics platform
+
+---
+
+### Multi-Cloud Strategy
+**Goal**: Design for multi-cloud deployment
+
+**Sequence**:
+1. Compare AWS and GCP compute options
+2. Evaluate database services for compatibility
+3. Design portable IAM and security policies
+4. Plan networking and VPN connectivity
+5. Implement abstraction layers for cloud-specific services
+
+**Example**: High-availability system with cloud failover
+
+---
+
+## Skill Combinations
+
+### With API Skills (`discover-api`)
+- Serverless REST APIs with Lambda or Cloud Functions
+- API Gateway integration patterns
+- GraphQL resolvers on serverless
+- API authentication with cloud identity services
+
+**Common combos**:
+- `aws/aws-lambda-functions.md` + `api/rest-api-design.md`
+- `gcp/gcp-serverless.md` + `api/graphql-schema-design.md`
+
+---
+
+### With Database Skills (`discover-database`)
+- Cloud-managed databases vs self-hosted
+- Database migration to cloud
+- Replication and backup strategies
+- Connection pooling for serverless
+
+**Common combos**:
+- `aws/aws-databases.md` + `database/postgres-query-optimization.md`
+- `gcp/gcp-databases.md` + `database/mongodb-schema-design.md`
+
+---
+
+### With Container Skills (`discover-containers`)
+- Container orchestration on cloud (ECS, EKS, GKE)
+- Serverless containers (Lambda, Cloud Run)
+- Container registries and security
+- Auto-scaling containerized apps
+
+**Common combos**:
+- `aws/aws-ec2-compute.md` + `containers/kubernetes-deployment.md`
+- `gcp/gcp-compute.md` + `containers/docker-best-practices.md`
+
+---
+
+### With Infrastructure Skills (`discover-infrastructure`)
+- Infrastructure as Code (Terraform, CloudFormation)
+- Cost optimization strategies
+- Multi-region deployments
+- Disaster recovery planning
+
+**Common combos**:
+- `aws/aws-networking.md` + `infrastructure/terraform-patterns.md`
+- `gcp/gcp-iam-security.md` + `infrastructure/infrastructure-security.md`
+
+---
+
+### With CI/CD Skills (`discover-cicd`)
+- Deployment pipelines for cloud services
+- Serverless deployment automation
+- Blue-green and canary deployments
+- Infrastructure testing
+
+**Common combos**:
+- `aws/aws-lambda-functions.md` + `cicd/github-actions-workflows.md`
+- `gcp/gcp-serverless.md` + `cicd/deployment-strategies.md`
+
+---
+
+## Quick Selection Guide
+
+**AWS vs GCP - When to Choose**:
+
+**Choose AWS when**:
+- Need widest service selection
+- Require specific AWS services (SageMaker, Athena, etc.)
+- Enterprise with existing AWS infrastructure
+- Need mature third-party integrations
+- Want detailed billing and cost management
+
+**Choose GCP when**:
+- Need strong Kubernetes integration (GKE)
+- Want simpler networking model
+- Require BigQuery for analytics
+- Prefer cleaner, more consistent APIs
+- Need competitive pricing on compute and networking
+
+**Multi-cloud when**:
+- Avoiding vendor lock-in is critical
+- Need geographic coverage across providers
+- Regulatory requirements mandate redundancy
+- Leveraging best-of-breed services from each
+
+---
+
+**Serverless vs Compute**:
+
+**Choose Serverless (Lambda/Cloud Functions) when**:
+- Variable or unpredictable traffic
+- Event-driven architectures
+- Want zero server management
+- Need automatic scaling
+- Cost optimization for low traffic
+
+**Choose Compute (EC2/Compute Engine) when**:
+- Predictable, steady workloads
+- Need full control over environment
+- Running legacy or stateful applications
+- Require specific OS or kernel customization
+- Cost optimization for high utilization
+
+**Choose Containers (ECS/GKE/Cloud Run) when**:
+- Need portability across environments
+- Complex microservices architectures
+- Want orchestration capabilities
+- Balancing control and automation
+- Hybrid serverless-compute workloads
+
+---
+
+**Database Selection**:
+
+**Relational (RDS/Cloud SQL)**:
+- ACID transactions required
+- Complex queries and joins
+- Existing SQL applications
+- Strong consistency needed
+
+**NoSQL (DynamoDB/Firestore)**:
+- Need horizontal scaling
+- Flexible schema requirements
+- Key-value or document access patterns
+- Low-latency at scale
+
+**Global (Aurora/Spanner)**:
+- Multi-region active-active
+- Global consistency
+- High availability requirements
+- Massive scale with SQL
+
+---
+
+## Loading Skills
+
+All AWS skills:
+```bash
+cat skills/cloud/aws/aws-lambda-functions.md
+cat skills/cloud/aws/aws-api-gateway.md
+cat skills/cloud/aws/aws-databases.md
+cat skills/cloud/aws/aws-iam-security.md
+cat skills/cloud/aws/aws-storage.md
+cat skills/cloud/aws/aws-ec2-compute.md
+cat skills/cloud/aws/aws-networking.md
+```
+
+All GCP skills:
+```bash
+cat skills/cloud/gcp/gcp-serverless.md
+cat skills/cloud/gcp/gcp-compute.md
+cat skills/cloud/gcp/gcp-databases.md
+cat skills/cloud/gcp/gcp-storage.md
+cat skills/cloud/gcp/gcp-iam-security.md
+cat skills/cloud/gcp/gcp-networking.md
+```
+
+**Pro tip**: Start with compute options (serverless vs VMs), then add storage, databases, networking, and security in layers.
+
+---
+
+**Related Categories**:
+- `discover-api` - API design and implementation
+- `discover-database` - Database design and optimization
+- `discover-containers` - Docker and Kubernetes
+- `discover-infrastructure` - Infrastructure as Code
+- `discover-cicd` - Deployment automation
+- `discover-observability` - Monitoring and logging
+- `discover-networking` - Network protocols and optimization

--- a/skills/discover-cloud/SKILL.md
+++ b/skills/discover-cloud/SKILL.md
@@ -23,9 +23,24 @@ This skill auto-activates when you're working with:
 
 ### Quick Reference
 
-The Cloud category contains 0 skills:
+The Cloud category contains 13 skills:
 
+**AWS Skills (7)**:
+1. **aws-lambda-functions** - Lambda function development, triggers, optimization
+2. **aws-api-gateway** - REST/HTTP/WebSocket APIs, authorization, integrations
+3. **aws-databases** - RDS, DynamoDB, ElastiCache, Aurora
+4. **aws-iam-security** - IAM, Cognito, Secrets Manager, KMS
+5. **aws-storage** - S3, EBS, EFS, Glacier, lifecycle policies
+6. **aws-ec2-compute** - EC2, Auto Scaling, Load Balancing, AMIs
+7. **aws-networking** - VPC, security groups, Route53, CloudFront
 
+**GCP Skills (6)**:
+1. **gcp-serverless** - Cloud Functions, Cloud Run, App Engine
+2. **gcp-compute** - Compute Engine, GKE, autoscaling
+3. **gcp-databases** - Cloud SQL, Firestore, Bigtable, Spanner
+4. **gcp-storage** - Cloud Storage, Persistent Disk, Filestore
+5. **gcp-iam-security** - IAM, service accounts, Secret Manager, KMS
+6. **gcp-networking** - VPC, firewall, Cloud DNS, Cloud CDN
 
 ### Load Full Category Details
 
@@ -46,7 +61,22 @@ This loads the full Cloud category index with:
 Load individual skills as needed:
 
 ```bash
+# AWS Skills
+cat skills/cloud/aws/aws-lambda-functions.md
+cat skills/cloud/aws/aws-api-gateway.md
+cat skills/cloud/aws/aws-databases.md
+cat skills/cloud/aws/aws-iam-security.md
+cat skills/cloud/aws/aws-storage.md
+cat skills/cloud/aws/aws-ec2-compute.md
+cat skills/cloud/aws/aws-networking.md
 
+# GCP Skills
+cat skills/cloud/gcp/gcp-serverless.md
+cat skills/cloud/gcp/gcp-compute.md
+cat skills/cloud/gcp/gcp-databases.md
+cat skills/cloud/gcp/gcp-storage.md
+cat skills/cloud/gcp/gcp-iam-security.md
+cat skills/cloud/gcp/gcp-networking.md
 ```
 
 ## Progressive Loading

--- a/skills/discover-protocols/SKILL.md
+++ b/skills/discover-protocols/SKILL.md
@@ -26,14 +26,14 @@ This skill auto-activates when you're working with:
 
 The Protocols category contains 8 skills:
 
-1. **http-fundamentals** - HTTP/1.1 basics, methods, headers, status codes
-2. **http2-multiplexing** - HTTP/2 with multiplexing, server push, HPACK
-3. **http3-quic** - HTTP/3 over QUIC, 0-RTT, connection migration
-4. **tcp-fundamentals** - TCP protocol, handshake, flow control, congestion
-5. **udp-fundamentals** - UDP protocol, connectionless communication
-6. **quic-protocol** - QUIC transport layer deep dive
-7. **protocol-selection** - Guide for choosing protocols
-8. **protocol-debugging** - Debug protocols with tcpdump, Wireshark, curl
+1. **grpc-implementation** - gRPC services with Protocol Buffers, streaming RPCs
+2. **http2-multiplexing** - HTTP/2 binary protocol, multiplexing, server push, HPACK
+3. **kafka-streams** - Apache Kafka stream processing and event streaming
+4. **mqtt-messaging** - MQTT pub-sub messaging for IoT and real-time applications
+5. **amqp-rabbitmq** - RabbitMQ and AMQP message broker implementation
+6. **protobuf-schemas** - Protocol Buffers schema design, evolution, code generation
+7. **tcp-optimization** - TCP performance optimization and tuning
+8. **websocket-protocols** - WebSocket protocol implementation, scaling, production
 
 ### Load Full Category Details
 
@@ -54,36 +54,48 @@ This loads the full Protocols category index with:
 Load individual skills as needed:
 
 ```bash
-cat skills/protocols/http-fundamentals.md
+cat skills/protocols/grpc-implementation.md
 cat skills/protocols/http2-multiplexing.md
-cat skills/protocols/tcp-fundamentals.md
-cat skills/protocols/protocol-debugging.md
+cat skills/protocols/kafka-streams.md
+cat skills/protocols/mqtt-messaging.md
+cat skills/protocols/amqp-rabbitmq.md
+cat skills/protocols/protobuf-schemas.md
+cat skills/protocols/tcp-optimization.md
+cat skills/protocols/websocket-protocols.md
 ```
 
 ## Common Workflows
 
-### Web Development
+### gRPC Microservices
 ```bash
-# HTTP basics → HTTP/2 optimization → Debugging
-cat skills/protocols/http-fundamentals.md
+# Schema design → gRPC implementation → Optimization
+cat skills/protocols/protobuf-schemas.md
+cat skills/protocols/grpc-implementation.md
 cat skills/protocols/http2-multiplexing.md
-cat skills/protocols/protocol-debugging.md
+cat skills/protocols/tcp-optimization.md
 ```
 
-### Protocol Selection
+### Event Streaming Pipeline
 ```bash
-# Understand options → Choose protocol → Implement
-cat skills/protocols/protocol-selection.md
-cat skills/protocols/tcp-fundamentals.md
-cat skills/protocols/udp-fundamentals.md
+# Kafka setup → Stream processing → Schema evolution
+cat skills/protocols/kafka-streams.md
+cat skills/protocols/protobuf-schemas.md
 ```
 
-### Performance Optimization
+### Real-time IoT Platform
 ```bash
-# Current protocol → Modern alternatives → Debug issues
-cat skills/protocols/http-fundamentals.md
-cat skills/protocols/http3-quic.md
-cat skills/protocols/protocol-debugging.md
+# MQTT for devices → RabbitMQ for backend → WebSockets for web
+cat skills/protocols/mqtt-messaging.md
+cat skills/protocols/amqp-rabbitmq.md
+cat skills/protocols/websocket-protocols.md
+```
+
+### High-Performance Web Application
+```bash
+# HTTP/2 optimization → WebSocket for real-time → TCP tuning
+cat skills/protocols/http2-multiplexing.md
+cat skills/protocols/websocket-protocols.md
+cat skills/protocols/tcp-optimization.md
 ```
 
 ## Progressive Loading

--- a/skills/protocols/INDEX.md
+++ b/skills/protocols/INDEX.md
@@ -1,0 +1,324 @@
+# Protocol Skills
+
+Comprehensive skills for implementing network protocols, message queues, and communication systems.
+
+## Category Overview
+
+**Total Skills**: 8
+**Focus**: gRPC, HTTP/2, Kafka, MQTT, RabbitMQ, Protocol Buffers, TCP, WebSockets
+**Use Cases**: API communication, message streaming, IoT, real-time applications, microservices
+
+## Skills in This Category
+
+### grpc-implementation.md
+**Description**: Implementing gRPC APIs with Protocol Buffers
+**Lines**: ~350
+**Use When**:
+- Implementing gRPC services from scratch
+- Designing Protocol Buffer schemas for RPC
+- Implementing streaming RPCs (unary, server, client, bidirectional)
+- Adding error handling and status codes
+- Implementing interceptors and middleware
+- Optimizing gRPC performance
+- Building microservices with gRPC
+
+**Key Concepts**: gRPC services, Protocol Buffers, streaming, error handling, interceptors, deadlines
+
+---
+
+### http2-multiplexing.md
+**Description**: HTTP/2 protocol with multiplexing, server push, header compression
+**Lines**: ~360
+**Use When**:
+- Optimizing website performance with HTTP/2
+- Implementing HTTP/2 servers or clients
+- Debugging HTTP/2 connection issues
+- Understanding multiplexing and stream prioritization
+- Implementing server push for resource optimization
+- Using HPACK for header compression
+- Migrating from HTTP/1.1 to HTTP/2
+
+**Key Concepts**: HTTP/2 binary protocol, multiplexing, server push, HPACK, stream prioritization
+
+---
+
+### kafka-streams.md
+**Description**: Apache Kafka stream processing and event streaming platform
+**Lines**: ~300
+**Use When**:
+- Building real-time data pipelines with Kafka
+- Implementing event-driven architectures
+- Processing streams with Kafka Streams or ksqlDB
+- Ensuring exactly-once message delivery
+- Using Avro/Protobuf with Schema Registry
+- Monitoring consumer lag and cluster health
+- Designing topic partitioning strategies
+
+**Key Concepts**: Kafka architecture, producers, consumers, Kafka Streams API, exactly-once semantics, schema registry
+
+---
+
+### mqtt-messaging.md
+**Description**: MQTT pub-sub messaging for IoT and real-time applications
+**Lines**: ~400
+**Use When**:
+- Implementing MQTT pub-sub messaging systems
+- Building IoT device communication
+- Designing lightweight messaging protocols
+- Implementing real-time sensor data collection
+- Setting up MQTT brokers (Mosquitto, EMQX, HiveMQ)
+- Configuring QoS levels and message delivery guarantees
+- Managing device connectivity and last will messages
+
+**Key Concepts**: MQTT protocol, pub-sub patterns, QoS levels, broker configuration, IoT integration, retained messages
+
+---
+
+### amqp-rabbitmq.md
+**Description**: RabbitMQ and AMQP message broker implementation
+**Lines**: ~350
+**Use When**:
+- Implementing message queuing with RabbitMQ
+- Designing exchange and queue topologies
+- Building work queue, pub-sub, routing, or RPC patterns
+- Implementing message durability and acknowledgments
+- Setting up RabbitMQ clustering and high availability
+- Optimizing RabbitMQ performance
+- Handling dead letter queues and message TTL
+
+**Key Concepts**: AMQP 0-9-1 protocol, RabbitMQ, exchanges, queues, routing patterns, clustering, high availability
+
+---
+
+### protobuf-schemas.md
+**Description**: Protocol Buffers schema design, evolution, and code generation
+**Lines**: ~350
+**Use When**:
+- Designing Protocol Buffer schemas from scratch
+- Implementing schema evolution strategies
+- Managing schema versioning and compatibility
+- Generating code for multiple languages
+- Integrating with gRPC or Kafka
+- Setting up schema registries
+- Ensuring backward/forward compatibility
+
+**Key Concepts**: Proto syntax, schema design, field numbering, backward/forward compatibility, code generation, schema registry
+
+---
+
+### tcp-optimization.md
+**Description**: TCP performance optimization and tuning
+**Lines**: ~370
+**Use When**:
+- Optimizing network throughput and latency
+- Tuning TCP for high-bandwidth or high-latency networks
+- Diagnosing TCP performance issues
+- Configuring congestion control algorithms
+- Optimizing cloud networking (AWS, GCP, Azure)
+- Tuning container networking (Docker, Kubernetes)
+- Adjusting TCP kernel parameters for performance
+
+**Key Concepts**: TCP tuning, congestion control, kernel parameters, performance monitoring, throughput optimization
+
+---
+
+### websocket-protocols.md
+**Description**: WebSocket protocol implementation, scaling, and production deployment
+**Lines**: ~650
+**Use When**:
+- Implementing WebSocket servers from scratch
+- Designing real-time bidirectional communication systems
+- Scaling WebSocket applications horizontally
+- Configuring load balancers for WebSocket traffic (nginx, HAProxy)
+- Implementing authentication and authorization for WebSocket connections
+- Handling reconnection logic and heartbeats
+- Monitoring WebSocket connections in production
+
+**Key Concepts**: WebSocket protocol (RFC 6455), connection management, load balancing, scaling strategies, security
+
+---
+
+## Common Workflows
+
+### gRPC Microservices
+**Goal**: Build a gRPC-based microservices architecture
+
+**Sequence**:
+1. `protobuf-schemas.md` - Design Protocol Buffer schemas
+2. `grpc-implementation.md` - Implement gRPC services
+3. `tcp-optimization.md` - Optimize network performance
+4. `http2-multiplexing.md` - Understand underlying HTTP/2 transport
+
+**Example**: Service mesh with gRPC communication
+
+---
+
+### Real-time Event Streaming
+**Goal**: Build an event streaming pipeline
+
+**Sequence**:
+1. `kafka-streams.md` - Set up Kafka cluster and topics
+2. `protobuf-schemas.md` - Define event schemas
+3. `kafka-streams.md` - Implement stream processing
+
+**Example**: Real-time analytics on user events
+
+---
+
+### IoT Message Brokering
+**Goal**: Implement IoT device communication
+
+**Sequence**:
+1. `mqtt-messaging.md` - Set up MQTT broker and topics
+2. `amqp-rabbitmq.md` - Route messages to backend services
+3. `websocket-protocols.md` - Enable real-time web dashboards
+
+**Example**: Smart home device network
+
+---
+
+### Message Queue Architecture
+**Goal**: Build reliable message processing system
+
+**Sequence**:
+1. `amqp-rabbitmq.md` - Design RabbitMQ topology
+2. `protobuf-schemas.md` - Define message schemas
+3. `kafka-streams.md` - Alternative: Kafka for high-throughput scenarios
+
+**Example**: Asynchronous job processing system
+
+---
+
+### Real-time Web Application
+**Goal**: Build bidirectional real-time communication
+
+**Sequence**:
+1. `websocket-protocols.md` - Implement WebSocket server
+2. `http2-multiplexing.md` - Optimize HTTP/2 for initial page load
+3. `tcp-optimization.md` - Tune network performance
+
+**Example**: Collaborative editing platform
+
+---
+
+## Skill Combinations
+
+### With API Skills (`discover-api`)
+- gRPC as alternative to REST APIs
+- Protocol Buffers for API schemas
+- WebSockets for real-time API updates
+- HTTP/2 for REST API performance
+
+**Common combos**:
+- `grpc-implementation.md` + `api/rest-api-design.md`
+- `websocket-protocols.md` + `api/api-authentication.md`
+
+---
+
+### With Database Skills (`discover-database`)
+- Kafka for change data capture (CDC)
+- Message queues for database write buffering
+- Real-time data synchronization
+- Event sourcing patterns
+
+**Common combos**:
+- `kafka-streams.md` + `database/postgres-cdc.md`
+- `amqp-rabbitmq.md` + `database/database-transactions.md`
+
+---
+
+### With Infrastructure Skills (`discover-infrastructure`, `discover-cloud`)
+- Deploying message brokers at scale
+- Container networking optimization
+- Cloud-native messaging services
+- Service mesh integration
+
+**Common combos**:
+- `tcp-optimization.md` + `infrastructure/infrastructure-security.md`
+- `kafka-streams.md` + `cloud/aws/aws-msk.md`
+
+---
+
+### With Frontend Skills (`discover-frontend`)
+- WebSocket client libraries
+- Real-time UI updates
+- Server-Sent Events vs WebSockets
+- Connection management in browsers
+
+**Common combos**:
+- `websocket-protocols.md` + `frontend/react-data-fetching.md`
+- `http2-multiplexing.md` + `frontend/nextjs-performance.md`
+
+---
+
+## Quick Selection Guide
+
+**Choose gRPC when**:
+- Building microservices with type-safe contracts
+- Need high-performance RPC
+- Want built-in streaming support
+- Working in polyglot environments (code generation for many languages)
+
+**Choose Kafka when**:
+- Need high-throughput event streaming
+- Building event-driven architectures
+- Require durable message logs
+- Need exactly-once processing guarantees
+
+**Choose RabbitMQ when**:
+- Need flexible routing patterns
+- Want mature AMQP implementation
+- Require priority queues and message TTL
+- Building traditional work queues
+
+**Choose MQTT when**:
+- Working with IoT devices
+- Need lightweight protocol for constrained networks
+- Implementing pub-sub for sensors/actuators
+- Require different QoS levels per message
+
+**Choose WebSockets when**:
+- Need bidirectional browser communication
+- Building real-time web applications
+- Want simple persistent connections
+- Implementing chat, notifications, or collaborative features
+
+**HTTP/2 vs HTTP/1.1**:
+- HTTP/2 for modern applications (multiplexing, server push)
+- Requires TLS for browser support
+- Better performance for multiple resources
+- Backward compatible at application layer
+
+**TCP Optimization priorities**:
+- Cloud environments: Tune for latency and bandwidth product
+- Containerized apps: Adjust kernel parameters
+- High-throughput: Focus on congestion control algorithms
+- Low-latency: Minimize buffering and enable TCP_NODELAY
+
+---
+
+## Loading Skills
+
+All skills are available in the `skills/protocols/` directory:
+
+```bash
+cat skills/protocols/grpc-implementation.md
+cat skills/protocols/http2-multiplexing.md
+cat skills/protocols/kafka-streams.md
+cat skills/protocols/mqtt-messaging.md
+cat skills/protocols/amqp-rabbitmq.md
+cat skills/protocols/protobuf-schemas.md
+cat skills/protocols/tcp-optimization.md
+cat skills/protocols/websocket-protocols.md
+```
+
+**Pro tip**: Start with protocol selection based on your use case, then load specific implementation guides. Combine with infrastructure skills for production deployment.
+
+---
+
+**Related Categories**:
+- `discover-api` - API design and implementation
+- `discover-database` - Data persistence and streaming
+- `discover-infrastructure` - Deployment and scaling
+- `discover-frontend` - Client-side integration
+- `discover-debugging` - Network debugging and monitoring


### PR DESCRIPTION
- Add skills/cloud/INDEX.md with all 13 cloud skills (7 AWS, 6 GCP)
- Add skills/protocols/INDEX.md with all 8 protocol skills
- Update discover-cloud/SKILL.md to show correct skill count (was 0, now 13)
- Update discover-protocols/SKILL.md to list actual skills (was outdated)
- Fix skill references and workflow examples in both gateways

These changes ensure successful plugin installation via /plugin install.
All gateway skills now correctly reference their category INDEX.md files.