### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Atomic Skills for Claude Code
 
+[![Run in Smithery](https://smithery.ai/badge/skills/rand)](https://smithery.ai/skills?ns=rand&utm_source=github&utm_medium=badge)
+
+
 [![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blue)](https://docs.claude.com/en/docs/claude-code/plugins)
 [![Skills](https://img.shields.io/badge/Skills-447-green)](skills/)
 [![License](https://img.shields.io/badge/License-MIT-yellow)](LICENSE)


### PR DESCRIPTION
## Add skill discoverability badge

Your 41 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Claude Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/rand)](https://smithery.ai/skills?ns=rand&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.